### PR TITLE
php 8.4 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
           - "windows-latest"
@@ -76,6 +77,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "composer-plugin",
   "require": {
-    "php": "8.1.*|8.2.*|8.3.*",
+    "php": "8.1.*|8.2.*|8.3.*|8.4.*",
     "composer-plugin-api": "^2.0"
   },
   "require-dev": {

--- a/tests/LicenseCheckPluginTest.php
+++ b/tests/LicenseCheckPluginTest.php
@@ -411,7 +411,7 @@ final class LicenseCheckPluginTest extends TestCase
         "license": "MIT",
         "type": "composer-plugin",
         "require": {
-          "php": "8.1.*|8.2.*|8.3.*",
+          "php": "8.1.*|8.2.*|8.3.*|8.4.*",
           "composer-plugin-api": "^2.0"
         },
         "require-dev": {


### PR DESCRIPTION
add php 8.4 compatibiltiy

unfortunately can't run psalm and infection in 8.4 ci as psalm is not 8.4 compatible (and personally doubt it ever will).

you might want to switch to using bare infection & phpstan, but that's a whole different discussion (though i'm more than happy to provide a pr for that) 😄 